### PR TITLE
✨feat: 연관어 크롤링 및 프론트 API 연결 구현

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,9 +3,14 @@ var express = require("express");
 var path = require("path");
 var cookieParser = require("cookie-parser");
 var logger = require("morgan");
+const axios = require('axios');
+const cheerio = require('cheerio');
 
+// 라우터 추가
 var indexRouter = require("./src/routes/index");
 var companyRouter = require("./src/routes/company");
+var keywordRouter = require("./src/routes/keyword"); //연관검색어 router
+
 const db = require("./src/models/DB");
 
 var app = express();
@@ -30,8 +35,11 @@ db.sequelize
     console.error("Unable to connect to the database:", err);
   });
 
+// 라우터 url 설정
 app.use("/api", indexRouter);
 app.use("/api/company", companyRouter);
+app.use("/api/keyword",keywordRouter);
+
 
 
 // catch 404 and forward to error handler

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "http-errors": "~1.6.3",
     "https": "^1.0.0",
     "morgan": "~1.9.1",
+    "nodemon": "^3.1.4",
     "pg": "^8.12.0",
     "pg-hstore": "^2.3.4",
     "python-shell": "^5.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-psycopg2
-pandas
-gensim
-python-dotenv
+gensim==4.3.2
+pandas==2.2.2
+psycopg2==2.9.9
+psycopg2-binary==2.9.9
+python-dotenv==1.0.1
+scipy==1.10.0

--- a/src/routes/keyword.js
+++ b/src/routes/keyword.js
@@ -1,0 +1,129 @@
+var express = require("express");
+var router = express.Router();
+var axios = require("axios");
+
+//fetchKeyword: 검색어-연관어 키워드 가져오기
+async function fetchKeyword(body) {
+    const baseURL = 'https://m.some.co.kr/sometrend/analysis/composite/v2/association-transition';
+    const headers = {
+        'Content-Type' : 'application/json',
+        'User-Agent' : 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36',
+    }    
+    try {
+        const response = await axios.post(baseURL, body, headers);
+        const respdata = response.data.item.dataList[0].data.rows[0];
+        // console.log(respdata.associationData.slice(0,12));
+        return respdata.associationData.slice(0,12);
+    } catch (error) {
+        console.error('Error fetching data:', error);
+        return null;
+    }
+}
+
+
+router.post('/', async (req,res) => {
+    //body에 필요한 객체
+    console.log(req.data);
+    const { keyword, scoringKeyword, startDate, endDate } = req.body;
+
+    const body = {
+        keyword,
+        scoringKeyword,
+        startDate,
+        endDate,
+        "analysisMonth": 0,
+        "categoryList" : "politician,celebrity,sportsman,characterEtc,government,business,agency,groupEtc,tourism,restaurant,shopping,scene,placeEtc,brandFood,cafe,brandBeverage,brandElectronics,brandFurniture,brandBeauty,brandFashion,brandEtc,productFood,productBeverage,productElectronics,productFurniture,productBeauty,productFashion,productEtc,economy,social,medicine,education,culture,sports,cultureEtc,animal,plant,naturalPhenomenon,naturalEtc",
+        "categorySetName": "SMT",
+        "exForHash": "",
+        "excludeWordOperators": "||",
+        "includeWordOperators": "||",
+        "keywordFilterExcludes": null,
+        "keywordFilterIncludes": null,
+        "period": "1",
+        "sources": "news",
+        "synonym": null,
+        "topN": 500
+    };
+
+    try {
+        const result = await fetchKeyword(body);
+        if (result) {
+            res.json({ data: result });
+        } else {
+            res.status(500).json({ error: 'Failed to fetch data' });
+        }
+    } catch (error) {
+        console.error('Error in /api/keyword:', error);
+        res.status(500).json({ error: 'Server error' });
+    }
+});
+
+//fetchNews: 검색어-연관어 간의 관련 news 가져오기
+async function fetchNews(body) {
+    const baseURL = 'https://some.co.kr/sometrend/analysis/composite/v2/documents/score';
+    const headers = {
+        'Content-Type' : 'application/json',
+        'User-Agent' : 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36',
+    }
+    
+    try {
+        const response = await axios.post(baseURL, body, headers);
+        const respdata = response.data.item['ko.news']; //뉴스기사 속성태그
+
+        return respdata;
+    } catch (error) {
+        console.error('Error fetching data:', error);
+        return null;
+    }
+}
+
+router.post('/news', async (req,res) => {
+    //body에 필요한 객체
+    const { keyword, scoringKeyword, ex, startDate, endDate } = req.body;
+
+    if (!keyword || !scoringKeyword || !startDate || !endDate) {
+        return res.status(400).json({ error: 'keyword, scoringKeyword, startDate, and endDate are required' });
+    }
+
+    const body = {    
+        ex,
+        keyword,
+        scoringKeyword,
+        startDate,
+        endDate,
+        // "ex": {
+        //     "blog": ["삼양식품"], "news": ["삼양식품"]
+        //     },
+        //     "keyword": "불닭",
+        //     "scoringKeyword": "불닭",
+        //     "startDate": "20240614",
+        //     "endDate": "20240620",
+            "analysisMonth": 0,
+            "categoryList" : "politician,celebrity,sportsman,characterEtc,government,business,agency,groupEtc,tourism,restaurant,shopping,scene,placeEtc,brandFood,cafe,brandBeverage,brandElectronics,brandFurniture,brandBeauty,brandFashion,brandEtc,productFood,productBeverage,productElectronics,productFurniture,productBeauty,productFashion,productEtc,economy,social,medicine,education,culture,sports,cultureEtc,animal,plant,naturalPhenomenon,naturalEtc",
+            "categorySetName": "TSN",
+            "exForHash": "",
+            "excludeWordOperators": "||",
+            "includeWordOperators": "||",
+            "keywordFilterExcludes": null,
+            "keywordFilterIncludes": null,
+            "period": "1",
+            "sources": "news",
+            "synonym": null,
+            "topN": 500
+    };
+
+    try {
+        const result = await fetchNews(body);
+        if (result) {
+            res.json({ data: result });
+        } else {
+            res.status(500).json({ error: 'Failed to fetch data' });
+        }
+    } catch (error) {
+        console.error('Error in /api/news:', error);
+        res.status(500).json({ error: 'Server error' });
+    }
+});
+
+
+module.exports = router;


### PR DESCRIPTION
## #️⃣ 작업한 내용 요약
> 다음과 같은 형태로 적어주세요 (ex. - [ ] 작업 내용 || - [x] 작업 내용)

- [x] 백엔드 썸트렌드 크롤링 요청 구현

## 🍩 위키에 올릴 내용 정리
> 위키에 올릴 내용을 정리해주세요 (자유롭게 적어주세요)
- 썸트렌드 웹페이지에서 keyword, scoringkeyword, startdate, enddate 등을 params에 담아 POST 요청합니다.
- 프론트에서 relatedKeywordAPI로 백엔드 중간매개로 요청하여 데이터를 불러옵니다.
- 검색어 기반 연관어는 startdate 기준으로 이번주와 저번주 데이터를 가져올 수 있는데, 이번주가 해당날짜 기준 -7일인지 혹은 월-금 기준 이번 주인지 (ex. 수요일이면 월요일부터 이번주로 3일치) 확인이 필요할 것 같습니다. 해당 부분은 주말에 테스트 후 공유하겠습니다!~

## ⚙️ 이슈 번호
> 관련된 이슈를 적어주세요 (ex. -close #37 || #37)
- close #18 

<br></br>
